### PR TITLE
라인 차트 렌더링

### DIFF
--- a/front/lib/main.dart
+++ b/front/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:snail/splash.dart';
+import 'package:snail/tests/result/dashboard/linechart.dart';
 
 void main() {
   runApp(MyApp());
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
       ),
       title: 'SNaiL',
       home: Scaffold(
-        body: SplashScreen(),
+        body: LineChartSample2(),
       ), //처음 접하는 화면을 SplashScreen으로 설정.
     );
   }

--- a/front/lib/main.dart
+++ b/front/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:snail/tests/result/dashboard/linechart.dart';
+import 'package:snail/tests/result/parentdashboard.dart';
 
 void main() {
   runApp(MyApp());
@@ -16,7 +16,7 @@ class MyApp extends StatelessWidget {
       ),
       title: 'SNaiL',
       home: Scaffold(
-        body: LineChartSample2(),
+        body: ParentMonthlyDashboardScreen(),
       ), //처음 접하는 화면을 SplashScreen으로 설정.
     );
   }

--- a/front/lib/tests/guides/story_guide.dart
+++ b/front/lib/tests/guides/story_guide.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:snail/tests/guides/backspace_guide.dart';
-import 'package:snail/tests/test/story_test.dart';
+import 'package:snail/tests/tests/story_test/story_video.dart';
 
 class MyNavigatorObserver extends NavigatorObserver {
   final GlobalKey<NavigatorState> navigatorKey;

--- a/front/lib/tests/result/dashboard/linechart.dart
+++ b/front/lib/tests/result/dashboard/linechart.dart
@@ -1,0 +1,232 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class LineChartSample2 extends StatefulWidget {
+  const LineChartSample2({Key? key}) : super(key: key);
+
+  @override
+  State<LineChartSample2> createState() => _LineChartSample2State();
+}
+
+class _LineChartSample2State extends State<LineChartSample2> {
+  bool showAvg = false;
+
+  // 예시 데이터
+  // 순서대로 1~12월 데이터라 생각해주세요!
+  final List<List<double>> monthlyData = [
+    [0.5, 0.6, 0.8, 0.9, 1.0], //1월
+    [0.1, 0.4, 0.5, 0.7, 0.9], //2월
+    [0.3, 0.5, 0.9, 1.0, 0.8], //3월
+    [0.5, 0.6, 0.8, 0.9, 1.0], //4월
+    [0.6, 0.4, 0.5, 0.7, 0.2], //5월
+    [0.5, 0.6, 0.8, 0.9, 1.0], //6월
+    [0.1, 0.4, 0.5, 0.7, 0.9], //7월
+    [0.3, 0.5, 0.9, 1.0, 0.8], //8월
+    [0.5, 0.6, 0.8, 0.9, 1.0], //9월
+    [0.6, 0.4, 0.5, 0.7, 0.2], //10월
+    [0.5, 0.6, 0.8, 0.9, 1.0], //1월
+    [0.1, 0.4, 0.5, 0.7, 0.9], //2월
+  ];
+
+  //평균으로 변환하는 함수
+  List<FlSpot> getMonthlyAverage(int month) {
+    final data = monthlyData[month];
+    final average = data.fold(0.0, (sum, value) => sum + value) / data.length;
+    return List.generate(
+      data.length,
+      //역량에 100을 곱한 후, 해당 월의 데이터를 적용
+      (index) => FlSpot(index.toDouble(), average * 100),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: <Widget>[
+        AspectRatio(
+          aspectRatio: 1.70,
+          child: Padding(
+            padding: const EdgeInsets.only(
+              right: 18,
+              left: 12,
+              top: 24,
+              bottom: 12,
+            ),
+            child: LineChart(
+              showAvg ? avgData() : mainData(),
+            ),
+          ),
+        ),
+        SizedBox(
+          width: 60,
+          height: 34,
+          child: TextButton(
+            onPressed: () {
+              setState(() {
+                showAvg = !showAvg;
+              });
+            },
+            child: Text(
+              'avg',
+              style: TextStyle(
+                fontSize: 12,
+                color: showAvg ? Colors.white.withOpacity(0.5) : Colors.white,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  LineChartData mainData() {
+    List<FlSpot> allSpots = []; // 꺾은선 그래프 저장
+    //1월~5월
+    for (int monthIndex = 0; monthIndex < 12; monthIndex++) {
+      final average =
+          monthlyData[monthIndex].fold(0.0, (sum, value) => sum + value) /
+              monthlyData[monthIndex].length;
+      allSpots.add(FlSpot(monthIndex.toDouble(), average * 100)); //월별 평균 데이터
+    }
+
+    return LineChartData(
+      gridData: FlGridData(
+        show: true,
+        drawVerticalLine: false,
+        horizontalInterval: 10,
+        verticalInterval: 20,
+        getDrawingHorizontalLine: (value) {
+          return FlLine(
+            color: Color(0XFFd9d9d9),
+            strokeWidth: 1,
+          );
+        },
+      ),
+      titlesData: FlTitlesData(
+        show: true,
+        bottomTitles: SideTitles(
+          showTitles: true,
+          reservedSize: 30,
+          getTitles: (value) {
+            final monthLabels = [
+              '1월',
+              '2월',
+              '3월',
+              '4월',
+              '5월',
+              '6월',
+              '7월',
+              '8월',
+              '9월',
+              '10월',
+              '11월',
+              '12월',
+            ];
+            final monthIndex = value.toInt();
+            if (monthIndex >= 0 && monthIndex < monthLabels.length) {
+              return monthLabels[monthIndex];
+            }
+            return '';
+          },
+          interval: 1,
+        ),
+        leftTitles: SideTitles(
+          showTitles: true,
+          interval: 10,
+          reservedSize: 100,
+          getTitles: (value) {
+            return '${value.toInt()}';
+          },
+        ),
+        rightTitles: SideTitles(
+          showTitles: false,
+        ),
+        topTitles: SideTitles(
+          showTitles: false, // 차트 위의 숫자 표시 비활성화
+        ),
+      ),
+      borderData: FlBorderData(
+        show: true,
+        border: Border.all(color: const Color(0xffffff)),
+      ),
+      minX: 0,
+      maxX: monthlyData.length.toDouble() - 1,
+      minY: 0,
+      maxY: 100,
+      lineBarsData: [
+        LineChartBarData(
+            spots: allSpots,
+            isCurved: true,
+            colors: [Color(0XFFffcb39)],
+            barWidth: 5,
+            isStrokeCapRound: true,
+            dotData: FlDotData(
+              show: false,
+            ),
+            belowBarData: BarAreaData(show: true, colors: [
+              Color(0XFFffcb39).withOpacity(0.3),
+              Colors.white.withOpacity(0.3)
+            ]))
+      ],
+    );
+  }
+
+  LineChartData avgData() {
+    return LineChartData(
+      lineTouchData: LineTouchData(enabled: false),
+      gridData: FlGridData(
+        show: false,
+        drawHorizontalLine: false,
+        verticalInterval: 20,
+        horizontalInterval: 1,
+        getDrawingVerticalLine: (value) {
+          return FlLine(
+            color: Color(0xffd9d9d9),
+            strokeWidth: 1,
+          );
+        },
+        getDrawingHorizontalLine: (value) {
+          return FlLine(
+            color: Color(0xffd9d9d9),
+            strokeWidth: 1,
+          );
+        },
+      ),
+      borderData: FlBorderData(
+        show: true,
+        border: Border.all(color: const Color(0xffd9d9d9)),
+      ),
+      minX: 0,
+      maxX: 6,
+      minY: 0,
+      maxY: 120,
+      lineBarsData: [
+        LineChartBarData(
+          spots: const [
+            FlSpot(0, 3.44),
+            FlSpot(2.6, 3.44),
+            FlSpot(4.9, 3.44),
+            FlSpot(6.8, 3.44),
+            FlSpot(8, 3.44),
+            FlSpot(9.5, 3.44),
+            FlSpot(11, 3.44),
+          ],
+          isCurved: true,
+          colors: [Color(0XFFffcb39)],
+          barWidth: 5,
+          isStrokeCapRound: true,
+          dotData: FlDotData(
+            show: false,
+          ),
+          belowBarData: BarAreaData(
+            show: true,
+            colors: [
+              Color(0XFFffcb39).withOpacity(0.3),
+              Colors.white.withOpacity(0.3)
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/front/lib/tests/result/dashboard/linechart.dart
+++ b/front/lib/tests/result/dashboard/linechart.dart
@@ -24,8 +24,8 @@ class _LineChartSample2State extends State<LineChartSample2> {
     [0.3, 0.5, 0.9, 1.0, 0.8], //8월
     [0.5, 0.6, 0.8, 0.9, 1.0], //9월
     [0.6, 0.4, 0.5, 0.7, 0.2], //10월
-    [0.5, 0.6, 0.8, 0.9, 1.0], //1월
-    [0.1, 0.4, 0.5, 0.7, 0.9], //2월
+    [0.5, 0.6, 0.8, 0.9, 1.0], //11월
+    [0.1, 0.4, 0.5, 0.7, 0.9], //12월
   ];
 
   //평균으로 변환하는 함수
@@ -156,12 +156,12 @@ class _LineChartSample2State extends State<LineChartSample2> {
       lineBarsData: [
         LineChartBarData(
             spots: allSpots,
-            isCurved: true,
+            isCurved: false,
             colors: [Color(0XFFffcb39)],
             barWidth: 5,
             isStrokeCapRound: true,
             dotData: FlDotData(
-              show: false,
+              show: true,
             ),
             belowBarData: BarAreaData(show: true, colors: [
               Color(0XFFffcb39).withOpacity(0.3),
@@ -211,12 +211,12 @@ class _LineChartSample2State extends State<LineChartSample2> {
             FlSpot(9.5, 3.44),
             FlSpot(11, 3.44),
           ],
-          isCurved: true,
+          isCurved: false,
           colors: [Color(0XFFffcb39)],
           barWidth: 5,
           isStrokeCapRound: true,
           dotData: FlDotData(
-            show: false,
+            show: true,
           ),
           belowBarData: BarAreaData(
             show: true,

--- a/front/lib/tests/result/parentdashboard.dart
+++ b/front/lib/tests/result/parentdashboard.dart
@@ -2,12 +2,69 @@ import 'package:flutter/material.dart';
 import 'package:snail/tests/result/dashboard/linechart.dart';
 import 'package:snail/tests/result/dashboard/chartbox.dart';
 
-class ParentMonhlyDashboardScreen extends StatelessWidget {
-  final List<double> data = [0.3, 0.5, 0.9, 0.9, 0.8]; //이번 달 점수
-  final List<double> avgData = [0.1, 0.4, 0.5, 0.7, 0.9]; //지난 달 점수
+class ParentMonthlyDashboardScreen extends StatelessWidget {
+  final List<double> currentData = [0.3, 0.5, 0.9, 0.4, 0.8]; //최근 검사 점수
+  final List<double> lastMonthData = [0.1, 0.4, 0.5, 0.7, 0.9]; //지난 달 점수
+
+  //역량 이름
+  List<String> titleList = [
+    '주의력(A)',
+    '기억력(B)',
+    '처리 능력(C)',
+    '언어 능력(D)',
+    '유연성(E)',
+  ];
+
+  List<String> descriptionList = [
+    '외부 자극으로부터 일정 시간동안 지속적으로 주의를 유지하는 능력을 말해요. 한 가지 활동에 집중해야 하는 상황에서 중요한 능력이에요.',
+    '정보를 저장하고 꺼내어 활용할 수 있는 능력이에요. 필요한 준비물을 챙기는 것과 같이 수많은 일상 활동들이 기억력과 연관되어 있어요.',
+    '정보를 빠르고 정확하게 처리하는 능력을 말해요. 처리 능력은 특히 기본적인 학습 기술인 읽기, 연산 등의 분야와 관련된 능력이에요.',
+    '사회의 구성원으로서 사회에서 사용되는 언어를 자연스럽게 사용하는 능력이에요. 일상에서 상대에게 이야기하고 싶은 내용을 잘 전달할 수 있어요.',
+    '유연성은 습관화된 반응이나 사고를 극복하고 새로운 상황에 적응하는 능력이에요. 물체, 생각 또는 상황을 동시에 고려할 때 필요한 능력이에요.'
+  ];
 
   @override
   Widget build(BuildContext context) {
+    //핵심 역량 = 최근 검사 역량의 점수가 직전 검사 역량의 점수보다 높을 때
+    List<Widget> corevaluelist = [];
+    for (int i = 0; i < 5; i++) {
+      if (currentData[i] > lastMonthData[i]) {
+        corevaluelist.add(
+          Column(
+            children: [
+              ChartBox(
+                title: titleList[i],
+                description: descriptionList[i],
+                dataValue: currentData[i],
+                avgDataValue: lastMonthData[i],
+              ),
+              SizedBox(height: 36),
+            ],
+          ),
+        );
+      }
+    }
+
+    //취약 역량 = 최근 검사 역량의 점수가 직전 검사 역량의 점수보다 낮을 때
+    List<Widget> weakvaluelist = [];
+    for (int i = 0; i < 5; i++) {
+      if (currentData[i] < lastMonthData[i]) {
+        weakvaluelist.add(
+          Column(
+            children: [
+              ChartBox(
+                title: titleList[i],
+                description: descriptionList[i],
+                dataValue: currentData[i],
+                avgDataValue: lastMonthData[i],
+              ),
+              SizedBox(height: 36),
+            ],
+          ),
+        );
+      }
+    }
+
     return Scaffold(
       body: SingleChildScrollView(
         child: Center(
@@ -37,7 +94,7 @@ class ParentMonhlyDashboardScreen extends StatelessWidget {
                   mainAxisSize: MainAxisSize.max,
                   children: [
                     Text(
-                      '핵심 역량',
+                      '지난 달과 비교해',
                       style: TextStyle(
                         color: Colors.black,
                         fontSize: 32,
@@ -45,7 +102,6 @@ class ParentMonhlyDashboardScreen extends StatelessWidget {
                       ),
                     ),
                     Spacer(),
-                    //라벨!
                     Container(color: Color(0xFFffcb39), width: 55, height: 20),
                     SizedBox(width: 7),
                     Text('최근 검사'),
@@ -58,71 +114,47 @@ class ParentMonhlyDashboardScreen extends StatelessWidget {
               ),
               SizedBox(height: 30),
               Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  ChartBox(
-                    title: '주의력(A)',
-                    description:
-                        '외부 자극으로부터 일정 시간동안 지속적으로 주의를 유지하는 능력을 말해요. 한 가지 활동에 집중해야 하는 상황에서 중요한 능력이에요.',
-                    dataValue: data[0],
-                    avgDataValue: avgData[0],
-                  ),
-                  SizedBox(height: 36), // 각 차트 박스 사이 간격 조절
-                  ChartBox(
-                    title: '기억력(B)',
-                    description:
-                        '정보를 저장하고 꺼내어 활용할 수 있는 능력이에요. 필요한 준비물을 챙기는 것과 같이 수많은 일상 활동들이 기억력과 연관되어 있어요.',
-                    dataValue: data[1],
-                    avgDataValue: avgData[1],
-                  ),
-                  SizedBox(height: 36),
-                  ChartBox(
-                    title: '처리 능력(C)',
-                    description:
-                        '정보를 빠르고 정확하게 처리하는 능력을 말해요. 처리 능력은 특히 기본적인 학습 기술인 읽기, 연산 등의 분야와 관련된 능력이에요.',
-                    dataValue: data[2],
-                    avgDataValue: avgData[2],
-                  ),
-                  SizedBox(height: 70),
                   Text(
-                    '취약역량',
+                    '이 역량이 발달했어요!',
                     style: TextStyle(
                       color: Colors.black,
-                      fontSize: 32,
-                      fontWeight: FontWeight.w700,
+                      fontSize: 24,
+                    ),
+                    textAlign: TextAlign.start,
+                  ),
+                  // 핵심 역량: 지난 달 검사보다 최근 검사의 점수가 높은 역량
+                  ...corevaluelist,
+                  SizedBox(height: 100),
+                  Text(
+                    '이 역량은 조금만 지켜봐주세요!',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 24,
                     ),
                   ),
-                  ChartBox(
-                    title: '기억력(B)',
-                    description:
-                        '정보를 저장하고 꺼내어 활용할 수 있는 능력이에요. 필요한 준비물을 챙기는 것과 같이 수많은 일상 활동들이 기억력과 연관되어 있어요.',
-                    dataValue: data[1],
-                    avgDataValue: avgData[1],
-                  ),
-                  SizedBox(height: 36),
-                  ChartBox(
-                    title: '처리 능력(C)',
-                    description:
-                        '정보를 빠르고 정확하게 처리하는 능력을 말해요. 처리 능력은 특히 기본적인 학습 기술인 읽기, 연산 등의 분야와 관련된 능력이에요.',
-                    dataValue: data[2],
-                    avgDataValue: avgData[2],
+                  ...weakvaluelist,
+                  ElevatedButton(
+                    onPressed: () {},
+                    child: Text(
+                      '돌아가기',
+                      style: TextStyle(
+                        color: Colors.black,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    style: ElevatedButton.styleFrom(
+                      primary: Color(0xFFffcb39),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      fixedSize: Size(165, 48),
+                    ),
                   ),
                   SizedBox(height: 100),
-                  ElevatedButton(
-                      onPressed: () {},
-                      child: Text(
-                        '돌아가기',
-                        style: TextStyle(
-                            color: Colors.black, fontWeight: FontWeight.w700),
-                      ),
-                      style: ElevatedButton.styleFrom(
-                        primary: Color(0xFFffcb39),
-                        shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(24)),
-                        fixedSize: Size(165, 48),
-                      )),
-                  SizedBox(height: 100)
                 ],
-              )
+              ),
             ],
           ),
         ),

--- a/front/lib/tests/result/parentdashboard.dart
+++ b/front/lib/tests/result/parentdashboard.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:snail/tests/result/dashboard/linechart.dart';
+import 'package:snail/tests/result/dashboard/chartbox.dart';
+
+class ParentMonhlyDashboardScreen extends StatelessWidget {
+  final List<double> data = [0.3, 0.5, 0.9, 0.9, 0.8]; //이번 달 점수
+  final List<double> avgData = [0.1, 0.4, 0.5, 0.7, 0.9]; //지난 달 점수
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: Center(
+          child: Column(
+            children: [
+              SizedBox(height: 70),
+              Column(
+                children: [
+                  Container(
+                    width: 1300,
+                    alignment: Alignment.centerLeft,
+                    child: Text(
+                      '달이의 AI 대시보드', //아이 이름 DB에서 꺼내와야 함.
+                      style:
+                          TextStyle(fontSize: 32, fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  SizedBox(height: 70),
+                  LineChartSample2(),
+                ],
+              ),
+              SizedBox(height: 126),
+              Container(
+                width: 1300,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  mainAxisSize: MainAxisSize.max,
+                  children: [
+                    Text(
+                      '핵심 역량',
+                      style: TextStyle(
+                        color: Colors.black,
+                        fontSize: 32,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    Spacer(),
+                    //라벨!
+                    Container(color: Color(0xFFffcb39), width: 55, height: 20),
+                    SizedBox(width: 7),
+                    Text('최근 검사'),
+                    SizedBox(width: 10),
+                    Container(color: Color(0xFFc4c4c4), width: 55, height: 20),
+                    SizedBox(width: 7),
+                    Text('지난 검사'),
+                  ],
+                ),
+              ),
+              SizedBox(height: 30),
+              Column(
+                children: [
+                  ChartBox(
+                    title: '주의력(A)',
+                    description:
+                        '외부 자극으로부터 일정 시간동안 지속적으로 주의를 유지하는 능력을 말해요. 한 가지 활동에 집중해야 하는 상황에서 중요한 능력이에요.',
+                    dataValue: data[0],
+                    avgDataValue: avgData[0],
+                  ),
+                  SizedBox(height: 36), // 각 차트 박스 사이 간격 조절
+                  ChartBox(
+                    title: '기억력(B)',
+                    description:
+                        '정보를 저장하고 꺼내어 활용할 수 있는 능력이에요. 필요한 준비물을 챙기는 것과 같이 수많은 일상 활동들이 기억력과 연관되어 있어요.',
+                    dataValue: data[1],
+                    avgDataValue: avgData[1],
+                  ),
+                  SizedBox(height: 36),
+                  ChartBox(
+                    title: '처리 능력(C)',
+                    description:
+                        '정보를 빠르고 정확하게 처리하는 능력을 말해요. 처리 능력은 특히 기본적인 학습 기술인 읽기, 연산 등의 분야와 관련된 능력이에요.',
+                    dataValue: data[2],
+                    avgDataValue: avgData[2],
+                  ),
+                  SizedBox(height: 70),
+                  Text(
+                    '취약역량',
+                    style: TextStyle(
+                      color: Colors.black,
+                      fontSize: 32,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  ChartBox(
+                    title: '기억력(B)',
+                    description:
+                        '정보를 저장하고 꺼내어 활용할 수 있는 능력이에요. 필요한 준비물을 챙기는 것과 같이 수많은 일상 활동들이 기억력과 연관되어 있어요.',
+                    dataValue: data[1],
+                    avgDataValue: avgData[1],
+                  ),
+                  SizedBox(height: 36),
+                  ChartBox(
+                    title: '처리 능력(C)',
+                    description:
+                        '정보를 빠르고 정확하게 처리하는 능력을 말해요. 처리 능력은 특히 기본적인 학습 기술인 읽기, 연산 등의 분야와 관련된 능력이에요.',
+                    dataValue: data[2],
+                    avgDataValue: avgData[2],
+                  ),
+                  SizedBox(height: 100),
+                  ElevatedButton(
+                      onPressed: () {},
+                      child: Text(
+                        '돌아가기',
+                        style: TextStyle(
+                            color: Colors.black, fontWeight: FontWeight.w700),
+                      ),
+                      style: ElevatedButton.styleFrom(
+                        primary: Color(0xFFffcb39),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(24)),
+                        fixedSize: Size(165, 48),
+                      )),
+                  SizedBox(height: 100)
+                ],
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/front/pubspec.lock
+++ b/front/pubspec.lock
@@ -234,13 +234,13 @@ packages:
     source: hosted
     version: "7.0.0"
   fl_chart:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: fl_chart
-      sha256: "0cc8f51e421f2a2113ea437a3c9c618e2dfec1c261fb177d433cc3573ba9bb91"
+      sha256: "57a4ecd718d001dd040204bdf9ed74c4cc9ec633137a5b740bc3a3209afb2b32"
       url: "https://pub.dev"
     source: hosted
-    version: "0.40.6"
+    version: "0.41.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/front/pubspec.yaml
+++ b/front/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   camera: ^0.10.5+3
+  fl_chart: '0.41.0'
 
 dev_dependencies:
   flutter_test:
@@ -61,7 +62,6 @@ dev_dependencies:
   # rules and activating additional ones.
   # video_js: ^0.1.3
   flutter_lints: ^2.0.0
-  fl_chart: ^0.40.0
   video_player: ^2.2.5
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
1. fl_chart 사용한 라인 차트 렌더링
2. 현재는 12개의 달로 임의로 설정
3. 예시로 사용한 데이터는 상단에 12개의 리스트로 정리(주석)
4. 다섯 개 숫자 더한 다음 5로 나누어 평균 구하고 100을 더하도록 함.